### PR TITLE
Replace deprecated function

### DIFF
--- a/action.php
+++ b/action.php
@@ -449,7 +449,8 @@ class action_plugin_dokusioc extends DokuWiki_Action_Plugin {
         // TODO: addLinksExtern
 
         /* previous and next revision */
-        $pagerevs = getRevisions($ID,0,$conf['recent']+1);
+        $changelog = new PageChangeLog($ID);
+        $pagerevs = $changelog->getRevisions(0,$conf['recent']+1);
         $prevrev = false; $nextrev = false;
         if (!$REV)
         {


### PR DESCRIPTION
Deprecated since 2013 November 
no fallback added..

Not tested..

For examples of replacements see the current compatibiltiy code at:
https://github.com/splitbrain/dokuwiki/blob/master/inc/changelog.php#L1089
