### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -96,7 +96,7 @@ class action_plugin_dokusioc extends DokuWiki_Action_Plugin {
     /**
     * Register its handlers with the DokuWiki's event controller
     */
-    function register(&$controller)
+    function register(Doku_Event_Handler $controller)
     {
         //print_r(headers_list()); die();
         

--- a/syntax.php
+++ b/syntax.php
@@ -29,8 +29,8 @@ class syntax_plugin_dokusioc extends DokuWiki_Syntax_Plugin {
     function getType() { return 'substition'; }
     function getSort() { return 999; }
     function connectTo($mode) { $this->Lexer->addSpecialPattern('\[SIOCCOMMENTS\]',$mode,'plugin_dokusioc'); }
-    function handle($match, $state, $pos, &$handler){ return array($match, $state, $pos); }
-    function render($mode, &$renderer, $data) {
+    function handle($match, $state, $pos, Doku_Handler $handler){ return array($match, $state, $pos); }
+    function render($mode, Doku_Renderer $renderer, $data) {
     /*
       if($mode == 'xhtml'){
           $renderer->doc .= '<div class="sioc-has_reply"></div><script type="text/javascript" charset="utf-8" src="http://n2.talis.com/svn/playground/kwijibo/javascript/sioc-comments/bundle.js"></script>';


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
